### PR TITLE
fixed typo that caused 404 - page not found

### DIFF
--- a/README_emulator.md
+++ b/README_emulator.md
@@ -62,7 +62,7 @@ To exectute one of the preset experiments or to run your own experiments you can
 python run.py experiment=test # will run whatever is specified by the configs/experiment/test.yml file
 ```
 
-You can make use of the [experiment template](emulator/configs/experiment/templatte.yaml).
+You can make use of the [experiment template](emulator/configs/experiment/template.yaml).
 
 
 ### Reproducing experiments


### PR DESCRIPTION
Fixed typo in link to experiment template that caused 404 - page not found error.